### PR TITLE
Add documentation and add namespace AsyncExtra.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ module AsyncResultExample
 
 open AsyncExtra
 
+// SETUP EXAMPLE-FUNCTIONS
 let fetchPersonIds: unit -> Async<List<int>> =
     fun () ->
         async {
@@ -53,6 +54,7 @@ let firstId: List<int> -> Result<int, string> =
         | Some id -> Ok id
         | None -> Error "Empty list of Ids"
 
+// SETUP EXAMPLE-FUNCTIONS DONE
 
 // Without AsyncExtra
 let firstPersonsName: unit -> Async<Result<string, string>> =

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Library for handling Async operations that might fail. Mainly gives you the type
 
 We wanted to practice [Railway Oriented Programming](https://fsharpforfunandprofit.com/rop/) in the Async world which is tricky in F# without helper functions.
 
-A common pattern in the real world is a service needs to parse the input, call different services, do DB-lookups, conversions, store and return something. These steps can usually fail in different ways. E.g. Invalid input, external request failed etc. In F# we have the `Result` type for things that might fail and `Async` for things that are asynchronous but we usually need the combination of these two, `AsyncResult`, which is not a type that exist in F#. This makes it hard to work with and requires a lot of plumbing (see example below).
+A common pattern in the real world is that a service needs to parse input, call different services, do DB-lookups, do conversions, store and return something. These steps can usually fail in different ways. E.g. Invalid input, external request failed etc. In F# we have the `Result` type for things that might fail and `Async` for things that are asynchronous but we usually need the combination of these two, `AsyncResult`, which is not a type that exist in F#. This makes it tedious to work with and requires a lot of plumbing (see example below).
 
 ### Inspiration
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Library for handling Async operations that might fail. Mainly gives you the type
 
 We wanted to practice [Railway Oriented Programming](https://fsharpforfunandprofit.com/rop/) in the Async world which is tricky in F# without helper functions.
 
-A common pattern in the real world is that a service needs to parse input, call different services, do DB-lookups, do conversions, store and return something. These steps can usually fail in different ways. E.g. Invalid input, external request failed etc. In F# we have the `Result` type for things that might fail and `Async` for things that are asynchronous but we usually need the combination of these two, `AsyncResult`, which is not a type that exist in F#. This makes it tedious to work with and requires a lot of plumbing (see example below).
+A common pattern in the real world is that a service needs to parse input, call different services, do DB-lookups, do conversions, store and return something. These steps can usually fail in different ways. E.g. Invalid input, external request failed, etc. In F# we have the `Result` type for things that might fail and `Async` for things that are asynchronous but we usually need the combination of these two, `AsyncResult`, which is not a type that exists in F#. This makes it tedious to work with and requires a lot of plumbing (see example below).
 
 ### Inspiration
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,83 @@
 # FSharp.AsyncExtra
 
 Library for handling Async operations that might fail. Mainly gives you the type `AsyncResult` and helper functions for creating and working with this type.
+
+### Why does it exist?
+
+We wanted to practice [Railway Oriented Programming](https://fsharpforfunandprofit.com/rop/) in the Async world which is tricky in F# without helper functions.
+
+A common pattern in the real world is a service needs to parse the input, call different services, do DB-lookups, conversions, store and return something. These steps can usually fail in different ways. E.g. Invalid input, external request failed etc. In F# we have the `Result` type for things that might fail and `Async` for things that are asynchronous but we usually need the combination of these two, `AsyncResult`, which is not a type that exist in F#. This makes it hard to work with and requires a lot of plumbing (see example below).
+
+### Inspiration
+
+This package is inspired by Scott Wlaschin's book - [Domain Modeling Made Functional](https://pragprog.com/book/swdddf/domain-modeling-made-functional) and the [associated code repository](https://github.com/swlaschin/DomainModelingMadeFunctional/blob/master/src/OrderTakingEvolved/Result.fs)
+
+### AsyncResult type
+
+The `AsyncResult` type is an alias
+
+```fsharp
+type AsyncResult<'success, 'error> = Async<Result<'success, 'error>>
+```
+
+### Example
+
+```fsharp
+module AsyncResultExample
+
+open AsyncExtra
+
+let fetchPersonIds: unit -> Async<List<int>> =
+    fun () ->
+        async {
+            do! Async.Sleep(3000)
+            return [ 31; 27; 92 ]
+        }
+
+let personName: string -> Async<Result<string, string>> =
+    fun id ->
+        async {
+            do! Async.Sleep(3000)
+            return match id with
+                   | "31" -> Ok "Alice"
+                   | "27" -> Ok "Bob"
+                   | "92" -> Ok "Scott"
+                   | _ -> Error "No person found"
+        }
+
+let firstId: List<int> -> Result<int, string> =
+    fun ids ->
+        ids
+        |> List.tryHead
+        |> function
+        | Some id -> Ok id
+        | None -> Error "Empty list of Ids"
+
+
+// Without AsyncExtra
+let firstPersonsName: unit -> Async<Result<string, string>> =
+    fun () ->
+        async {
+            let! personIds = fetchPersonIds()
+            let id =
+                personIds
+                |> firstId
+                |> Result.map string
+            let! name = match id with
+                        | Ok id -> personName id
+                        | Error error -> async.Return(Error error)
+            return name
+        }
+
+// With AsyncExtra
+let firstPersonsNameWithAsyncResult: unit -> AsyncResult<string, string> =
+    fun () ->
+        fetchPersonIds()
+        |> Async.map firstId
+        |> AsyncResult.map string
+        |> AsyncResult.bind personName
+
+
+```
+
+[![Insurello](https://gitcdn.xyz/repo/insurello/elm-swedish-bank-account-number/master/insurello.svg)](https://jobb.insurello.se/departments/product-tech)

--- a/src/AsyncExtra.Tests/AsyncExtraTests.fs
+++ b/src/AsyncExtra.Tests/AsyncExtraTests.fs
@@ -1,5 +1,6 @@
 module AsyncExtraTests
 
+open AsyncExtra
 open Expecto
 
 [<Tests>]

--- a/src/AsyncExtra/AsyncExtra.fs
+++ b/src/AsyncExtra/AsyncExtra.fs
@@ -1,4 +1,4 @@
-namespace global
+namespace AsyncExtra
 
 [<RequireQualifiedAccessAttribute>]
 module Async =


### PR DESCRIPTION
### Problem
- There is no documentation
- We are forcing the AsyncResult module to be opened globally which all users might not like.

### Solution
- Add documentation
- Don't open the AsyncResult module globally and use namespace `AsyncResult`

Co-authored-by: Emil Klasson <emil.klasson@insurello.se>